### PR TITLE
added autoload to org-journal-search

### DIFF
--- a/org-journal.el
+++ b/org-journal.el
@@ -541,6 +541,7 @@ prefix is given, don't add a new heading."
 ;;; Journal search facilities
 ;;
 
+;;;###autoload
 (defun org-journal-search (str &optional period-name)
   "Search for a string in the journal within a given interval.
 See `org-read-date` for information on ways to specify dates.


### PR DESCRIPTION
I have encountered an issue several times where I start Emacs and try to search for my journal for a keyword but `org-journal-search` is undefined. I have to open a journal before I can search.